### PR TITLE
resource names modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ from the `terraform/` directory you're in after running `terraform apply`.
 
 #### The Azure Function
 
-In your portal, go to the newly-created Azure Function. Its name will be the `<prefix>` value you put in during the Terraform deployment.
+In your portal, go to the newly-created Azure Function. Its name will be the `<prefix>-serverless-functionapp` value you put in during the Terraform deployment.
 
 There are a few things to notice:
 
@@ -176,7 +176,7 @@ which ensures that even if somebody were to submit Function code that attempted 
 
 #### The Logic App
 
-In your portal, go to the newly-created Logic App. Its name will be `<prefix>-LA` where `<prefix>` is the value you put in during the Terraform deployment.
+In your portal, go to the newly-created Logic App. Its name will be `<prefix>-serverless-la` where `<prefix>` is the value you put in during the Terraform deployment.
 
 ##### Execution Logic
 
@@ -206,7 +206,7 @@ The important part of the Logic App's configuration is that our Terraform deploy
 
 #### Key Vault
 
-In your portal, go to the newly-created Key Vault. Its name will be the `<prefix>` value you put in during the Terraform deployment.
+In your portal, go to the newly-created Key Vault. Its name will be the `<prefix>-serverless-kv` value you put in during the Terraform deployment.
 
 The important bits of the Key Vault for this sample are the `Events` and `Access Policies` area
 
@@ -226,11 +226,11 @@ In order for the Function App to be able to read the values of Key Vault secrets
 
 ## Bringing it all together
 
-If you open the Live Stream for the first Application Insights instance (without the `-2` suffix) you'll see the Function happily logging messages every 5 seconds or so:
+If you open the Live Stream for the first Application Insights instance (with the `-first` suffix) you'll see the Function happily logging messages every 5 seconds or so:
 
 ![](doc/appinsightslivestream1.png)
 
-Moving over to the secondary Application Insights, you'll probably see a screen like this:
+Moving over to the secondary Application Insights (with the `-second` suffix), you'll probably see a screen like this:
 
 ![](doc/appinsights2dead.png)
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ variable "sp_client_secret" {
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "serverless-sample-${var.prefix}"
+  name     = "${var.prefix}-serverless-sample"
   location = var.location
   tags = {
     sample = "serverless-keyvault-secret-rotation-handling"
@@ -49,7 +49,7 @@ resource "azurerm_resource_group" "rg" {
 ##################################################################################
 
 resource "azurerm_application_insights" "logging" {
-  name                = var.prefix
+  name                = "${var.prefix}-serverless-ai-first"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   application_type    = "web"
@@ -59,7 +59,7 @@ resource "azurerm_application_insights" "logging" {
 }
 
 resource "azurerm_application_insights" "logging2" {
-  name                = "${var.prefix}-2"
+  name                = "${var.prefix}-serverless-ai-second"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   application_type    = "web"
@@ -85,7 +85,7 @@ resource "azurerm_storage_account" "fxnstor" {
 }
 
 resource "azurerm_app_service_plan" "fxnapp" {
-  name                = var.prefix
+  name                = "${var.prefix}-serverless-serviceplan"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   kind                = "functionapp"
@@ -99,7 +99,7 @@ resource "azurerm_app_service_plan" "fxnapp" {
 }
 
 resource "azurerm_function_app" "fxn" {
-  name                      = var.prefix
+  name                      = "${var.prefix}-serverless-functionapp"
   resource_group_name       = azurerm_resource_group.rg.name
   location                  = azurerm_resource_group.rg.location
   app_service_plan_id       = azurerm_app_service_plan.fxnapp.id
@@ -124,7 +124,7 @@ resource "azurerm_function_app" "fxn" {
 ##################################################################################
 
 resource "azurerm_key_vault" "shared_key_vault" {
-  name                = var.prefix
+  name                = "${var.prefix}-serverless-kv"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   tenant_id           = data.azurerm_client_config.current.tenant_id
@@ -183,7 +183,7 @@ resource "azurerm_key_vault_secret" "logging_app_insights_key" {
 ##################################################################################
 
 resource "azurerm_log_analytics_workspace" "loganalytics" {
-  name                = "${var.prefix}-law"
+  name                = "${var.prefix}-serverless-law"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   sku                 = "PerGB2018"
@@ -196,7 +196,7 @@ resource "azurerm_log_analytics_workspace" "loganalytics" {
 locals {
   parameters_body = {
     logicapp_keyvaulthandler_name = {
-      value = "${var.prefix}-LA"
+      value = "${var.prefix}-serverless-la"
     },
     vaults_rollingvault_externalid = {
       value = azurerm_key_vault.shared_key_vault.id
@@ -226,7 +226,7 @@ locals {
 }
 
 resource "azurerm_template_deployment" "logicapp" {
-  name                = "${var.prefix}-LA-deployment"
+  name                = "${var.prefix}-serverless-la-deployment"
   resource_group_name = azurerm_resource_group.rg.name
   deployment_mode     = "Incremental"
   parameters_body     = jsonencode(local.parameters_body)
@@ -473,11 +473,11 @@ resource "azurerm_role_assignment" "laToFunction" {
 # Outputs
 ##################################################################################
 
-output "AppInsightsKey1" {
+output "AppInsightsKey-First" {
   value = azurerm_application_insights.logging.instrumentation_key
 }
 
-output "AppInsightsKey2" {
+output "AppInsightsKey-Second" {
   value = azurerm_application_insights.logging2.instrumentation_key
 }
 


### PR DESCRIPTION
[main.tf](https://github.com/Azure-Samples/serverless-keyvault-secret-rotation-handling/blob/master/terraform/main.tf) file needs a `prefix` to create resources on Azure (creating resources in Azure is explained in the [README.md](https://github.com/Azure-Samples/serverless-keyvault-secret-rotation-handling/blob/master/README.md) file)

resource group name is including `prefix` as `suffix` actually.

and usage of `prefix` when naming resources may cause conflict and provisioning resources in Azure may stop.

this PR is to fix `prefix` usage in naming resources.

also this PR has updates in the [README.md](https://github.com/Azure-Samples/serverless-keyvault-secret-rotation-handling/blob/master/README.md) file